### PR TITLE
Fix error in referenced Javascript

### DIFF
--- a/examples/spreadsheet-improved.html
+++ b/examples/spreadsheet-improved.html
@@ -10,7 +10,7 @@ a {border:1px solid #888;border-top:0;display:inline-block;margin:3px;padding:0 
 .formula {margin:3px;width:1337px;}
 </style>
 <body></body>
-<script src="http://cdn.jsdelivr.net/mithril/0.1.24/mithril.min.js"></script>
+<script src="//cdn.jsdelivr.net/mithril/0.1.24/mithril.min.js"></script>
 <script type="text/javascript">
 var data = JSON.parse(localStorage["spreadsheet"] || "{}")
 for (var cell in data) data[cell] = computable(data[cell])


### PR DESCRIPTION
Referenced javascript is hard-coded to HTTP. When navigated to from a HTTPS  blog-article[1], loading JS from this HTTP-resource fails.

This change makes the file always load via same protocol as HTML-page, fixing the error.

[1] https://lhorie.github.io/mithril-blog/a-spreadsheet-in-60-lines-of-javascript.html